### PR TITLE
Fix docs build and add `robots.txt`

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# <img src="http://www.aiida.net/wp-content/uploads/2020/06/logo_aiida.png" alt="AiiDA" width="200"/>
+
+### NOTE: This package is deprecated, except for currently being used as the main AiiDA readthedocs project.
+
+# AIIDA Meta-package
 
 AiiDA (www.aiida.net) is a workflow manager for computational science with a strong focus on provenance, performance and extensibility.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,5 @@
+
+project = 'aiida'
+
+# Override the default robots.txt
+html_extra_path = ['robots.txt']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,7 @@
 .. raw:: html
 
+    <meta http-equiv="refresh" content="1; url=https://aiida-core.readthedocs.io">
+    
     <script type="text/javascript">
     if (String(window.location).indexOf("readthedocs") !== -1) {
         window.location.replace('https://aiida-core.readthedocs.io');

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /projects/aiida-core/en/stable/
+Disallow: /


### PR DESCRIPTION
Here's the fix for the issue that old aiida documentation versions are showing up on google (https://github.com/aiidateam/aiida-core/issues/6516)

* fixed doc build (at some point, i think, readthedocs started requiring e.g. `.readthedocs.yml`. Added simple version of it.)
* added `robots.txt` to block every version of the docs from google except for `stable`
* also added a meta tag that should enable redirect to the aiida-core documentation even if javascript is disabled.

